### PR TITLE
`PB-61`: Add error to failure response.

### DIFF
--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -57,3 +57,29 @@ class TestClientMethods:
             e2e_client: A Client instance.
         """
         e2e_client.view_tokens()
+
+
+def test_failure_bad_client(e2e_client: Client):
+    """
+    Verify an error is returned when an unknown client is used.
+    """
+
+    client = e2e_client
+    client.email = "not_a_valid_email@mail.com"
+
+    node_name = "demo.Add"
+    inputs = {
+        "lhs": 1,
+        "rhs": 2,
+    }  # Inputs are left hand side and right hand side of equation
+
+    job_id = client.queue_node(node=node_name, input=inputs)
+
+    status = "PENDING"
+    while status == "PENDING":
+        response = e2e_client.job_status(job_id)
+        status = response["status"]
+        time.sleep(5)
+
+    assert response["status"] == "FAILURE"
+    assert "error" in response


### PR DESCRIPTION
This PR just adds a simple test that the changes in the backend mean an error message is returned rather than just a `FAILURE` status. These kinds of tests should be in the API but I'm adding an additional one here.