### PR TITLE
Bump `typeguard` version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1849,19 +1849,22 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "typeguard"
-version = "2.13.3"
+version = "4.4.2"
 description = "Run-time type checker for Python"
 optional = false
-python-versions = ">=3.5.3"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"},
-    {file = "typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4"},
+    {file = "typeguard-4.4.2-py3-none-any.whl", hash = "sha256:77a78f11f09777aeae7fa08585f33b5f4ef0e7335af40005b0c422ed398ff48c"},
+    {file = "typeguard-4.4.2.tar.gz", hash = "sha256:a6f1065813e32ef365bc3b3f503af8a96f9dd4e0033a02c28c4a4983de8c6c49"},
 ]
 
+[package.dependencies]
+typing_extensions = ">=4.10.0"
+
 [package.extras]
-doc = ["sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["mypy ; platform_python_implementation != \"PyPy\"", "pytest", "typing-extensions"]
+doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.3.0)"]
+test = ["coverage[toml] (>=7)", "mypy (>=1.2.0) ; platform_python_implementation != \"PyPy\"", "pytest (>=7)"]
 
 [[package]]
 name = "typing-extensions"
@@ -1929,4 +1932,4 @@ vis = ["matplotlib", "networkx"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "0f54450f04b607f383e476a5ca6f930c44009fcb1478bd5da5e606faeb078f32"
+content-hash = "ec8c8f800e16888fa7d84a6b9b301035b894f25dd0c5ef5440bb55b4da78b80f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-typeguard = ">=2.13.3,<2.14.0"
+typeguard = "^4.4.2"
 requests = "^2.32.3"
 matplotlib = { version = "^3.10.0", optional = true }
 networkx = { version = "^3.4.2", optional = true }

--- a/tests/unit/nodes/test_base.py
+++ b/tests/unit/nodes/test_base.py
@@ -1,8 +1,8 @@
 import pytest
+from uncertainty_engine_types import Handle
 
 from uncertainty_engine.nodes.base import Node
-
-from uncertainty_engine_types import Handle
+from typeguard import TypeCheckError
 
 
 def test_node():
@@ -30,7 +30,7 @@ def test_node_name_type():
     """
     Verify error is raised if node name is not a string.
     """
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeCheckError):
         Node(5)
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 import pytest
-from typeguard import typechecked
+from typeguard import TypeCheckError, typechecked
 from uncertainty_engine_types import Handle
 
 from uncertainty_engine import utils as ue_utils
@@ -112,8 +112,8 @@ def test_handle_union():
 
     # Make sure the function can be called with the correct types.
     generic_fn(1, 1.0, 1.0)
-    generic_fn(ue_utils.Handle("a.b"), 1.0, [1.0])
+    generic_fn(ue_utils.Handle("a.b"), 1.0, [1.0, 1.0])
     generic_fn(ue_utils.Handle("a.b"), ue_utils.Handle("a.b"), ue_utils.Handle("a.b"))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeCheckError):
         generic_fn(1, 1.0, "a.b")

--- a/uncertainty_engine/nodes/sensor_designer.py
+++ b/uncertainty_engine/nodes/sensor_designer.py
@@ -6,7 +6,7 @@ from uncertainty_engine_types import Handle, SensorDesigner, TabularData
 from uncertainty_engine.nodes.base import Node
 from uncertainty_engine.utils import HandleUnion, OldHandle, dict_to_csv_str
 
-ListDict = dict[str, list[float]]
+ListDict = dict[str, list[Union[float, int]]]
 
 
 @typechecked
@@ -32,24 +32,30 @@ class BuildSensorDesigner(Node):
     ):
         # Deal with the sensor data.
         if isinstance(sensor_data, Handle):
-            sensor_data = OldHandle(sensor_data)
+            sensor_data_processed = OldHandle(sensor_data)
         else:
-            sensor_data = TabularData(csv=dict_to_csv_str(sensor_data)).model_dump()
+            sensor_data_processed = TabularData(
+                csv=dict_to_csv_str(sensor_data)
+            ).model_dump()
 
         # Deal with the QOI data.
         if quantities_of_interest_data is not None:
             if isinstance(quantities_of_interest_data, Handle):
-                quantities_of_interest_data = OldHandle(quantities_of_interest_data)
+                quantities_of_interest_data_processed = OldHandle(
+                    quantities_of_interest_data
+                )
             else:
-                quantities_of_interest_data = TabularData(
+                quantities_of_interest_data_processed = TabularData(
                     csv=dict_to_csv_str(quantities_of_interest_data)
                 ).model_dump()
+        else:
+            quantities_of_interest_data_processed = None
 
         super().__init__(
             node_name=self.node_name,
             label=label,
-            sensor_data=sensor_data,
-            quantities_of_interest_data=quantities_of_interest_data,
+            sensor_data=sensor_data_processed,
+            quantities_of_interest_data=quantities_of_interest_data_processed,
             sigma=OldHandle(sigma) if isinstance(sigma, Handle) else sigma,
         )
 
@@ -76,14 +82,16 @@ class SuggestSensorDesign(Node):
     ):
         # Deal with the sensor designer.
         if isinstance(sensor_designer, Handle):
-            sensor_designer = OldHandle(sensor_designer)
+            sensor_designer_processed = OldHandle(sensor_designer)
         else:
-            sensor_designer = SensorDesigner(bed=sensor_designer["bed"]).model_dump()
+            sensor_designer_processed = SensorDesigner(
+                bed=sensor_designer["bed"]
+            ).model_dump()
 
         super().__init__(
             node_name=self.node_name,
             label=label,
-            sensor_designer=sensor_designer,
+            sensor_designer=sensor_designer_processed,
             num_sensors=num_sensors,
             num_eval=num_eval,
         )
@@ -109,13 +117,15 @@ class ScoreSensorDesign(Node):
     ):
         # Deal with the sensor designer.
         if isinstance(sensor_designer, Handle):
-            sensor_designer = OldHandle(sensor_designer)
+            sensor_designer_processed = OldHandle(sensor_designer)
         else:
-            sensor_designer = SensorDesigner(bed=sensor_designer["bed"]).model_dump()
+            sensor_designer_processed = SensorDesigner(
+                bed=sensor_designer["bed"]
+            ).model_dump()
 
         super().__init__(
             node_name=self.node_name,
             label=label,
-            sensor_designer=sensor_designer,
+            sensor_designer=sensor_designer_processed,
             design=OldHandle(design) if isinstance(design, Handle) else design,
         )


### PR DESCRIPTION
This PR bumps the `typeguard` version to `^4.4.2`.

Bumping the `typeguard` version highlighted some bad practices. Namely, changing the type of a variable function logic. This has been rectified by creating new variables when type is changed but it should be revisited.