### PR TITLE
Bump `uncertainty-engine-types` to 0.0.11

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1881,14 +1881,14 @@ markers = {dev = "python_version < \"3.11\""}
 
 [[package]]
 name = "uncertainty-engine-types"
-version = "0.0.4"
+version = "0.0.11"
 description = "Common type definitions for the Uncertainty Engine"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "uncertainty_engine_types-0.0.4-py3-none-any.whl", hash = "sha256:7da97fe5de265c6d4f97db7bac6ece792a7ebe3d7e84f95e015bd697e6315491"},
-    {file = "uncertainty_engine_types-0.0.4.tar.gz", hash = "sha256:cdc5d2cd91934097a9b21f4898d65486dc5485c4ebc4242c23dbc176e4899f1e"},
+    {file = "uncertainty_engine_types-0.0.11-py3-none-any.whl", hash = "sha256:64d3649ab019c38c3b3da426bbc6e1ed6b60676963799350e69604aa99e49572"},
+    {file = "uncertainty_engine_types-0.0.11.tar.gz", hash = "sha256:a028ea691e79e8d64c0c0d8fcee347f391c5f52aec9192c0b0404bf18cb36a9c"},
 ]
 
 [package.dependencies]
@@ -1932,4 +1932,4 @@ vis = ["matplotlib", "networkx"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "ec8c8f800e16888fa7d84a6b9b301035b894f25dd0c5ef5440bb55b4da78b80f"
+content-hash = "5b0029604016163b25e5ca7e4715804ec68454f271692411b96940020e10f633"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requests = "^2.32.3"
 matplotlib = { version = "^3.10.0", optional = true }
 networkx = { version = "^3.4.2", optional = true }
 ipykernel = { version = "^6.29.5", optional = true }
-uncertainty-engine-types = "^0.0.4"
+uncertainty-engine-types = "^0.0.11"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"

--- a/uncertainty_engine/nodes/sensor_designer.py
+++ b/uncertainty_engine/nodes/sensor_designer.py
@@ -1,7 +1,7 @@
 from typing import Optional, Union
 
 from typeguard import typechecked
-from uncertainty_engine_types import Handle, SensorDesigner, TabularData
+from uncertainty_engine_types import CSVDataset, Handle, SensorDesigner
 
 from uncertainty_engine.nodes.base import Node
 from uncertainty_engine.utils import HandleUnion, dict_to_csv_str
@@ -34,7 +34,7 @@ class BuildSensorDesigner(Node):
         if isinstance(sensor_data, Handle):
             sensor_data_processed = sensor_data
         else:
-            sensor_data_processed = TabularData(
+            sensor_data_processed = CSVDataset(
                 csv=dict_to_csv_str(sensor_data)
             ).model_dump()
 
@@ -43,7 +43,7 @@ class BuildSensorDesigner(Node):
             if isinstance(quantities_of_interest_data, Handle):
                 quantities_of_interest_data_processed = quantities_of_interest_data
             else:
-                quantities_of_interest_data_processed = TabularData(
+                quantities_of_interest_data_processed = CSVDataset(
                     csv=dict_to_csv_str(quantities_of_interest_data)
                 ).model_dump()
         else:


### PR DESCRIPTION
This PR bumps the version of `uncertainty-engine-types`.

In the latest of `uncertainty-engine-types` `TabularData` has changed its meaning. Any occurrences of `TabularData` is replaced with `CSVDataset` which acts like `TabularData` used to.