### PR TITLE
Remove `dev` from GitHub actions

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        branch: ["dev"]
+        branch: ["main"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linting_formatting.yaml
+++ b/.github/workflows/linting_formatting.yaml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - dev
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   linting_formatting:

--- a/.github/workflows/unit_functional_tests.yaml
+++ b/.github/workflows/unit_functional_tests.yaml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - dev
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   unit_tests:


### PR DESCRIPTION
We will soon be moving away from having two long living branches `main` and `dev` to just having `main`. As such, the actions are being updated to run on `main` only.