### PR TITLE
Add `ApiInvoker` and `HttpApiInvoker`

### DIFF
--- a/tests/unit/test_api_invoker.py
+++ b/tests/unit/test_api_invoker.py
@@ -3,12 +3,12 @@ from unittest.mock import Mock, patch
 
 from pytest import fixture
 
-from uncertainty_engine.api_invoker import LiveApiInvoker
+from uncertainty_engine.api_invoker import HttpApiInvoker
 
 
 @fixture
-def api() -> LiveApiInvoker:
-    return LiveApiInvoker("https://test-api")
+def api() -> HttpApiInvoker:
+    return HttpApiInvoker("https://test-api")
 
 
 @fixture
@@ -22,16 +22,16 @@ def req() -> Iterator[Mock]:
         yield patched_request
 
 
-def test_deserialize(api: LiveApiInvoker, req: Mock) -> None:
+def test_deserialize(api: HttpApiInvoker, req: Mock) -> None:
     assert api.get("/foo") == {"foo": "bar"}
 
 
-def test_get(api: LiveApiInvoker, req: Mock) -> None:
+def test_get(api: HttpApiInvoker, req: Mock) -> None:
     api.get("/foo")
     req.assert_called_once_with("GET", "https://test-api/foo")
 
 
-def test_post(api: LiveApiInvoker, req: Mock) -> None:
+def test_post(api: HttpApiInvoker, req: Mock) -> None:
     api.post(
         "/foo",
         {"greeting": "hello"},

--- a/tests/unit/test_api_invoker.py
+++ b/tests/unit/test_api_invoker.py
@@ -1,0 +1,44 @@
+from typing import Iterator
+from unittest.mock import Mock, patch
+
+from pytest import fixture
+
+from uncertainty_engine.api_invoker import LiveApiInvoker
+
+
+@fixture
+def api() -> LiveApiInvoker:
+    return LiveApiInvoker("https://test-api")
+
+
+@fixture
+def req() -> Iterator[Mock]:
+    response = Mock()
+    response.json = Mock(return_value={"foo": "bar"})
+
+    target = "uncertainty_engine.api_invoker.request"
+
+    with patch(target, return_value=response) as patched_request:
+        yield patched_request
+
+
+def test_deserialize(api: LiveApiInvoker, req: Mock) -> None:
+    assert api.get("/foo") == {"foo": "bar"}
+
+
+def test_get(api: LiveApiInvoker, req: Mock) -> None:
+    api.get("/foo")
+    req.assert_called_once_with("GET", "https://test-api/foo")
+
+
+def test_post(api: LiveApiInvoker, req: Mock) -> None:
+    api.post(
+        "/foo",
+        {"greeting": "hello"},
+    )
+
+    req.assert_called_once_with(
+        "POST",
+        "https://test-api/foo",
+        json={"greeting": "hello"},
+    )

--- a/uncertainty_engine/api_invoker.py
+++ b/uncertainty_engine/api_invoker.py
@@ -103,5 +103,5 @@ class HttpApiInvoker(ApiInvoker):
         return request(
             method,
             url,
-            **kwargs,  #  type: ignore
+            **kwargs,  # type: ignore
         ).json()

--- a/uncertainty_engine/api_invoker.py
+++ b/uncertainty_engine/api_invoker.py
@@ -1,0 +1,107 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+from requests import request
+
+
+class ApiInvoker(ABC):
+    """
+    Base implementation of an API invoker.
+    """
+
+    @abstractmethod
+    def _invoke(
+        self,
+        method: str,
+        path: str,
+        body: Any | None = None,
+    ) -> Any:
+        """
+        Invoke the API.
+
+        Args:
+            method: HTTP method.
+            path: API path.
+            body: Optional body.
+
+        Returns:
+            API response.
+        """
+
+    def get(self, path: str) -> Any:
+        """
+        Invoke a GET request.
+
+        Args:
+            path: API path.
+
+        Returns:
+            API response.
+        """
+
+        return self._invoke(
+            "GET",
+            path,
+        )
+
+    def post(self, path: str, body: Any) -> Any:
+        """
+        Invoke a POST request.
+
+        Args:
+            path: API path.
+            body: Request body.
+
+        Returns:
+            API response.
+        """
+
+        return self._invoke(
+            "POST",
+            path,
+            body=body,
+        )
+
+
+class LiveApiInvoker(ApiInvoker):
+    """
+    An implementation of `ApiInvoker` for live API calls.
+
+    Args:
+        endpoint: API endpoint. Must start with a protocol (i.e. "https://") and
+            must not end with a slash.
+    """
+
+    def __init__(self, endpoint: str) -> None:
+        self._endpoint = endpoint
+
+    def _invoke(
+        self,
+        method: str,
+        path: str,
+        body: Any | None = None,
+    ) -> Any:
+        """
+        Invoke the API.
+
+        Args:
+            method: HTTP method.
+            path: API path.
+            body: Optional body.
+
+        Returns:
+            API response.
+        """
+
+        url = self._endpoint + path
+
+        kwargs = {}
+
+        if body:
+            kwargs["json"] = body
+
+        return request(
+            method,
+            url,
+            **kwargs,  #  type: ignore
+        ).json()

--- a/uncertainty_engine/api_invoker.py
+++ b/uncertainty_engine/api_invoker.py
@@ -63,9 +63,9 @@ class ApiInvoker(ABC):
         )
 
 
-class LiveApiInvoker(ApiInvoker):
+class HttpApiInvoker(ApiInvoker):
     """
-    An implementation of `ApiInvoker` for live API calls.
+    An implementation of `ApiInvoker` for HTTP APIs.
 
     Args:
         endpoint: API endpoint. Must start with a protocol (i.e. "https://") and


### PR DESCRIPTION
## Overview

`ApiInvoker` is an abstract class for interacting with any API with "get" and "post" methods.

`HttpApiInvoker` is an implementation of `ApiInvoker` for HTTP APIs.

## Example

```python
from uncertainty_engine.api_invoker import HttpApiInvoker

api = HttpApiInvoker("https://api.uncertaintyengine.ai/core")

# Send a HTTP GET request to https://api.uncertaintyengine.ai/core/nodes/list.
response = api.get("/nodes/list")

```