### PR TITLE
Remove email from Client initialisation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-UE_USER_EMAIL=
 UE_DEPLOYMENT_URL=
 
 # Client configurations

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -5,7 +5,7 @@ on:
     - cron: "0 09,17 * * *" # Run every day at 9:00 and 17:00
 
 env:
-  UE_USER_EMAIL: ${{ secrets.UE_USER_EMAIL }}
+  UE_USERNAME: ${{ secrets.UE_USER_EMAIL }}
   UE_DEPLOYMENT_URL: ${{ secrets.UE_DEPLOYMENT_URL }}
 
 jobs:
@@ -38,4 +38,3 @@ jobs:
 
       - name: Run tests
         run: sh CI/run_tests_e2e.sh
-

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -21,25 +21,25 @@ classDiagram
         +account_id: str
         -_decoded_payload: Dict
     }
-    
+
     class CognitoAuthenticator {
-        +region: str 
+        +region: str
         +user_pool_id: str
         +client_id: str
         +client: boto3.client
     }
-    
+
     class AuthService {
         +account_id: str
         +token: CognitoToken
         +authenticator: CognitoAuthenticator
     }
-    
+
     class ApiProviderBase {
         +deployment: str
         +auth_service: AuthService
     }
-    
+
     class ResourceProvider {
         +deployment: str
         +auth_service: AuthService
@@ -47,14 +47,14 @@ classDiagram
         +projects_client: ProjectRecordsApi
         +resources_client: ResourcesApi
     }
-    
+
     class Client {
         +email: str
         +deployment: str
         +auth_service: AuthService
         +resources: ResourceProvider
     }
-    
+
     AuthService --* CognitoToken : contains
     AuthService --* CognitoAuthenticator : contains
     ApiProviderBase --* AuthService : contains
@@ -98,14 +98,10 @@ To add new API providers:
 
 ```python
 # Create client
-client = Client(email="user@example.com")
+client = Client()
 
 # Authenticate with credentials
 client.authenticate(
     account_id="123456789",
 )
 ```
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ from uncertainty_engine.nodes.demo import Add
 
 # Set up the client
 client = Client(
-   email="<user-email>",  # Must have tokens!
    deployment="<uncertainty-engine-api-url>",
 )
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -75,7 +75,6 @@ You will need to make sure you have all the [prerequisites](#prerequisites) abov
    from uncertainty_engine.client import Client
 
    client = Client(
-       email="<your-email>",  # Note: There must be token associated with this email.
        deployment="<a-deployment-url>",
    )
    ```

--- a/examples/demo_add.ipynb
+++ b/examples/demo_add.ipynb
@@ -46,7 +46,6 @@
    "outputs": [],
    "source": [
     "client = Client(\n",
-    "    email=\"<your-email>\",  # Note: There must be token associated with this email.\n",
     "    deployment=\"<a-deployment-url>\",\n",
     ")"
    ]
@@ -199,7 +198,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/demo_node.ipynb
+++ b/examples/demo_node.ipynb
@@ -34,7 +34,6 @@
     "from uncertainty_engine.client import Client\n",
     "\n",
     "client = Client(\n",
-    "    email=\"<your-email>\",  # Note: There must be token associated with this email.\n",
     "    deployment=\"<a-deployment-url>\",\n",
     ")"
    ]

--- a/examples/demo_resource.ipynb
+++ b/examples/demo_resource.ipynb
@@ -46,7 +46,6 @@
    "outputs": [],
    "source": [
     "client = Client(\n",
-    "    email=\"<you-email>\",  # Note: There must be token associated with this email.\n",
     "    deployment=\"<a-deployment-url>\",\n",
     "    resource_deployment=\"<a-deployment-url>\"\n",
     ")"

--- a/examples/demo_train_predict.ipynb
+++ b/examples/demo_train_predict.ipynb
@@ -28,7 +28,6 @@
     "from uncertainty_engine.client import Client\n",
     "\n",
     "client = Client(\n",
-    "    email=\"<your-email>\",  # Note: There must be token associated with this email.\n",
     "    deployment=\"<a-deployment-url>\",\n",
     ")"
    ]

--- a/examples/demo_workflow.ipynb
+++ b/examples/demo_workflow.ipynb
@@ -25,7 +25,6 @@
     "from uncertainty_engine.client import Client\n",
     "\n",
     "client = Client(\n",
-    "    email=\"<your-email>\",  # Note: There must be token associated with this email.\n",
     "    deployment=\"<a-deployment-url>\",\n",
     ")"
    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,14 +8,6 @@ from uncertainty_engine.nodes.basic import Add
 
 
 @pytest.fixture(scope="class")
-def test_user_email(request):
-    """
-    An email address for testing.
-    """
-    return getattr(request, "param", "a.user@digilab.co.uk")
-
-
-@pytest.fixture(scope="class")
 def deployment_url(request):
     """
     The deployment URL for the Uncertainty Engine service.
@@ -24,9 +16,9 @@ def deployment_url(request):
 
 
 @pytest.fixture(scope="class")
-def client(test_user_email: str, deployment_url: str):
+def client(deployment_url: str) -> Client:
     """Fixture to initialize the Client class once per test class."""
-    return Client(email=test_user_email, deployment=deployment_url)
+    return Client(deployment=deployment_url)
 
 
 @pytest.fixture(scope="module")
@@ -36,11 +28,10 @@ def e2e_client():
 
     NOTE: For the e2e tests to run successfully, the following environment variables must be set:
 
-        UE_USER_EMAIL: A user email that has been registered with the Uncertainty Engine service.
         UE_DEPLOYMENT_URL: The deployment URL for the Uncertainty Engine service.
     """
     return Client(
-        email=os.environ["UE_USER_EMAIL"], deployment=os.environ["UE_DEPLOYMENT_URL"]
+        deployment=os.environ["UE_DEPLOYMENT_URL"],
     )
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -9,28 +9,22 @@ from uncertainty_engine.nodes.base import Node
 # __init__
 
 
-def test_init_default(test_user_email: str):
+def test_init_default() -> None:
     """
     Verify that the Client class can be instantiated with the default deployment.
-
-    Args:
-        test_user_email: An email address for testing.
     """
-    client = Client(email=test_user_email)
 
-    assert client.email == test_user_email
+    client = Client()
+
     assert client.deployment == DEFAULT_DEPLOYMENT
 
 
-def test_init_custom(test_user_email: str):
+def test_init_custom() -> None:
     """
     Verify that the Client class can be instantiated with a custom deployment.
-
-    Args:
-        test_user_email: An email address for testing.
     """
     custom_deployment = "http://example.com"
-    client = Client(email=test_user_email, deployment=custom_deployment)
+    client = Client(deployment=custom_deployment)
 
     assert client.deployment == custom_deployment
 

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from os import environ
 from time import sleep
 from typing import Optional, Union
 
@@ -10,6 +11,7 @@ from uncertainty_engine.api_invoker import ApiInvoker, HttpApiInvoker
 from uncertainty_engine.api_providers import ResourceProvider
 from uncertainty_engine.auth_service import AuthService
 from uncertainty_engine.cognito_authenticator import CognitoAuthenticator
+from uncertainty_engine.exceptions import IncompleteCredentials
 from uncertainty_engine.nodes.base import Node
 
 DEFAULT_DEPLOYMENT = "http://localhost:8000/api"
@@ -46,7 +48,6 @@ class Job(BaseModel):
 class Client:
     def __init__(
         self,
-        email: str,
         deployment: str = DEFAULT_DEPLOYMENT,
         resource_deployment: str = DEFAULT_RESOURCE_DEPLOYMENT,
     ):
@@ -54,13 +55,11 @@ class Client:
         A client for interacting with the Uncertainty Engine.
 
         Args:
-            email: The email address of the user.
             deployment: The URL of the Uncertainty Engine deployment.
             resource_deployment: The URL of the resource deployment.
 
         Example:
             >>> client = Client(
-            ...   email="<user-email>",
             ...   deployment="<uncertainty-engine-api-url>",
             ... )
             >>> add_node = Add(lhs=1, rhs=2, label="add")
@@ -73,7 +72,6 @@ class Client:
         Core API interaction.
         """
 
-        self.email = email
         self.deployment = deployment
         authenticator = CognitoAuthenticator()
         self.auth_service = AuthService(authenticator)
@@ -92,6 +90,23 @@ class Client:
         self.auth_service.authenticate(account_id)
 
         self.resources.update_api_authentication()
+
+    @property
+    def email(self) -> str:
+        """
+        The user's username, which is expected to be their email address.
+
+        Raises:
+            IncompleteCredentials: Raised if the UE_USERNAME environment
+                variable is not set.
+        """
+
+        env_var = "UE_USERNAME"
+
+        if username := environ.get(env_var):
+            return username
+
+        raise IncompleteCredentials(env_var)
 
     def list_nodes(self, category: Optional[str] = None) -> list:
         """

--- a/uncertainty_engine/exceptions/__init__.py
+++ b/uncertainty_engine/exceptions/__init__.py
@@ -1,0 +1,5 @@
+from uncertainty_engine.exceptions.incomplete_credentials import IncompleteCredentials
+
+__all__ = [
+    "IncompleteCredentials",
+]

--- a/uncertainty_engine/exceptions/incomplete_credentials.py
+++ b/uncertainty_engine/exceptions/incomplete_credentials.py
@@ -1,0 +1,10 @@
+class IncompleteCredentials(Exception):
+    """
+    Raised when the user's credentials are incomplete.
+
+    Args:
+        env_var: The name of the environment variable that's incomplete.
+    """
+
+    def __init__(self, env_var: str) -> None:
+        super().__init__(f"The {env_var} environment variable must be set.")


### PR DESCRIPTION
The user's email address must now be set via the `UE_USERNAME` environment variable rather than via the `email` argument of the `Client` class.