### PR TITLE
Add authentication line to notebooks

### DIFF
--- a/examples/demo_add.ipynb
+++ b/examples/demo_add.ipynb
@@ -52,7 +52,8 @@
     "        region=\"<REGION>\",\n",
     "        resource_api=\"<UNCERTAINTY ENGINE RESOURCE SERVICE API URL>\",\n",
     "    ),\n",
-    ")"
+    ")\n",
+    "client.authenticate(\"<ACCOUNT ID>\")"
    ]
   },
   {
@@ -203,7 +204,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "uncertainty-engine-Jm6ucIAS-py3.12",
    "language": "python",
    "name": "python3"
   },

--- a/examples/demo_node.ipynb
+++ b/examples/demo_node.ipynb
@@ -40,7 +40,8 @@
     "        region=\"<REGION>\",\n",
     "        resource_api=\"<UNCERTAINTY ENGINE RESOURCE SERVICE API URL>\",\n",
     "    ),\n",
-    ")"
+    ")\n",
+    "client.authenticate(\"<ACCOUNT ID>\")"
    ]
   },
   {
@@ -142,7 +143,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "uncertainty-engine-Jm6ucIAS-py3.12",
    "language": "python",
    "name": "python3"
   },

--- a/examples/demo_train_predict.ipynb
+++ b/examples/demo_train_predict.ipynb
@@ -34,7 +34,8 @@
     "        region=\"<REGION>\",\n",
     "        resource_api=\"<UNCERTAINTY ENGINE RESOURCE SERVICE API URL>\",\n",
     "    ),\n",
-    ")"
+    ")\n",
+    "client.authenticate(\"<ACCOUNT ID>\")"
    ]
   },
   {
@@ -890,7 +891,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "uncertainty-engine-Jm6ucIAS-py3.12",
    "language": "python",
    "name": "python3"
   },

--- a/examples/demo_workflow.ipynb
+++ b/examples/demo_workflow.ipynb
@@ -31,7 +31,8 @@
     "        region=\"<REGION>\",\n",
     "        resource_api=\"<UNCERTAINTY ENGINE RESOURCE SERVICE API URL>\",\n",
     "    ),\n",
-    ")"
+    ")\n",
+    "client.authenticate(\"<ACCOUNT ID>\")"
    ]
   },
   {


### PR DESCRIPTION
This PR simply adds `client.authenticate("<ACCOUNT ID>")` to notebooks that didn't have it but need it. This is very much a stop gap whilst real documentation is worked on but this at least indicates what needs to happen so a user can ask even if they don't know what this is.