### PR TITLE
Add demo environment

### DIFF
--- a/uncertainty_engine/environments/demo.json
+++ b/uncertainty_engine/environments/demo.json
@@ -1,0 +1,6 @@
+{
+  "cognito_user_pool_client_id": "5oaq2109i1tvh9b2b6vnudah5t",
+  "core_api": "https://d8896s21fi.execute-api.eu-west-2.amazonaws.com",
+  "region": "eu-west-2",
+  "resource_api": "https://rlc0l300ek.execute-api.eu-west-2.amazonaws.com"
+}


### PR DESCRIPTION
Adds the demo environment.

This will allow connecting to the demo environment with:

```python
from uncertainty_engine import Client

client = Client(env="demo")
```