### PR TITLE
Add `delete_resource` method

### DIFF
--- a/tests/unit/api_providers/test_resource_provider.py
+++ b/tests/unit/api_providers/test_resource_provider.py
@@ -669,3 +669,56 @@ def test_list_resources_empty(resource_provider: ResourceProvider):
     resource_provider.resources_client.get_project_resource_records.assert_called_once_with(
         "test-project", "dataset"
     )
+
+
+def test_delete_resource_success(
+    resource_provider: ResourceProvider, capsys: pytest.CaptureFixture[str]
+):
+    """Test deleting a resource successfully."""
+    # Setup mock response
+    resource_provider.resources_client.delete_resource_record = MagicMock()
+
+    # Call the method
+    resource_provider.delete_resource("test-project", "dataset", "test-resource-id")
+
+    # Verify method calls
+    resource_provider.resources_client.delete_resource_record.assert_called_once_with(
+        "test-project", "dataset", "test-resource-id"
+    )
+
+    # Verify output
+    captured = capsys.readouterr()
+    assert (
+        "Resource test-resource-id deleted successfully from project test-project."
+        in captured.out
+    )
+
+
+def test_delete_generic_exception(resource_provider: ResourceProvider):
+    """Test handling of generic exception during resource deletion."""
+    # Setup exception
+    resource_provider.resources_client.delete_resource_record = MagicMock(
+        side_effect=ValueError("Random error")
+    )
+
+    # Call and verify exception
+    with pytest.raises(Exception) as exc_info:
+        resource_provider.delete_resource("test-project", "dataset", "test-resource-id")
+
+    # Verify output
+    assert str(exc_info.value) == "Error deleting resource: Random error"
+
+
+def test_delete_api_exception(resource_provider: ResourceProvider):
+    """Test handling of ApiException during resource deletion."""
+    # Setup exception
+    api_exception = ApiException(status=404, reason="Not Found")
+    resource_provider.resources_client.delete_resource_record = MagicMock(
+        side_effect=api_exception
+    )
+
+    # Call and verify exception
+    with pytest.raises(
+        Exception, match="Error deleting resource: API Error: Not Found"
+    ):
+        resource_provider.delete_resource("test-project", "dataset", "test-resource-id")

--- a/tests/unit/api_providers/test_resource_provider.py
+++ b/tests/unit/api_providers/test_resource_provider.py
@@ -672,14 +672,15 @@ def test_list_resources_empty(resource_provider: ResourceProvider):
 
 
 def test_delete_resource_success(
-    resource_provider: ResourceProvider, capsys: pytest.CaptureFixture[str]
+    resource_provider: ResourceProvider, caplog: pytest.LogCaptureFixture
 ):
     """Test deleting a resource successfully."""
     # Setup mock response
     resource_provider.resources_client.delete_resource_record = MagicMock()
 
-    # Call the method
-    resource_provider.delete_resource("test-project", "dataset", "test-resource-id")
+    with caplog.at_level("INFO"):
+        # Call the method
+        resource_provider.delete_resource("test-project", "dataset", "test-resource-id")
 
     # Verify method calls
     resource_provider.resources_client.delete_resource_record.assert_called_once_with(
@@ -687,10 +688,11 @@ def test_delete_resource_success(
     )
 
     # Verify output
-    captured = capsys.readouterr()
-    assert (
-        "Resource test-resource-id deleted successfully from project test-project."
-        in captured.out
+    assert any(
+        record.levelname == "INFO"
+        and record.getMessage()
+        == "Resource test-resource-id deleted successfully from project test-project."
+        for record in caplog.records
     )
 
 

--- a/uncertainty_engine/api_providers/resource_provider.py
+++ b/uncertainty_engine/api_providers/resource_provider.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any, Optional
 
@@ -20,6 +21,9 @@ from uncertainty_engine.api_providers.constants import (
 )
 from uncertainty_engine.auth_service import AuthService
 from uncertainty_engine.utils import format_api_error
+
+# Set up logging
+logger = logging.getLogger(__name__)
 
 
 class ResourceProvider(ApiProviderBase):
@@ -402,7 +406,7 @@ class ResourceProvider(ApiProviderBase):
             ...     resource_type="model",
             ...     resource_id="resource-456"
             ... )
-            "Resource resource-456 deleted successfully from project your-project-123."
+            # Will add INFO level log -- "Resource resource-456 deleted successfully from project your-project-123."
         """
         try:
             self.resources_client.delete_resource_record(
@@ -413,4 +417,6 @@ class ResourceProvider(ApiProviderBase):
         except Exception as e:
             raise Exception(f"Error deleting resource: {str(e)}")
 
-        print(f"Resource {resource_id} deleted successfully from project {project_id}.")
+        logger.info(
+            f"Resource {resource_id} deleted successfully from project {project_id}."
+        )

--- a/uncertainty_engine/api_providers/resource_provider.py
+++ b/uncertainty_engine/api_providers/resource_provider.py
@@ -397,7 +397,7 @@ class ResourceProvider(ApiProviderBase):
             resource_id: The ID of the resource you want to delete
 
         Example:
-            >>> client.delete_resource(
+            >>> client.resources.delete_resource(
             ...     project_id="your-project-123",
             ...     resource_type="model",
             ...     resource_id="resource-456"

--- a/uncertainty_engine/api_providers/resource_provider.py
+++ b/uncertainty_engine/api_providers/resource_provider.py
@@ -344,7 +344,7 @@ class ResourceProvider(ApiProviderBase):
             raise Exception(f"Error finalizing upload: {str(e)}")
 
     @ApiProviderBase.with_auth_refresh
-    def list_resources(self, project_id, resource_type: str) -> list:
+    def list_resources(self, project_id: str, resource_type: str) -> list[dict[str, Any]]:
         """
         Get a list of all resources of a specific type in your project.
 

--- a/uncertainty_engine/api_providers/resource_provider.py
+++ b/uncertainty_engine/api_providers/resource_provider.py
@@ -380,3 +380,37 @@ class ResourceProvider(ApiProviderBase):
             }
             for record in resource_records
         ]
+
+    @ApiProviderBase.with_auth_refresh
+    def delete_resource(
+        self, project_id: str, resource_type: str, resource_id: str
+    ) -> None:
+        """
+        Delete a resource from your project.
+
+        Use this method when you want to permanently remove a resource from your project.
+        Be cautious, as this action cannot be undone.
+
+        Args:
+            project_id: Your project's unique identifier
+            resource_type: The category of the file (e.g., "dataset", "model", "document")
+            resource_id: The ID of the resource you want to delete
+
+        Example:
+            >>> client.delete_resource(
+            ...     project_id="your-project-123",
+            ...     resource_type="model",
+            ...     resource_id="resource-456"
+            ... )
+            "Resource resource-456 deleted successfully from project your-project-123."
+        """
+        try:
+            self.resources_client.delete_resource_record(
+                project_id, resource_type, resource_id
+            )
+        except ApiException as e:
+            raise Exception(f"Error deleting resource: {format_api_error(e)}")
+        except Exception as e:
+            raise Exception(f"Error deleting resource: {str(e)}")
+
+        print(f"Resource {resource_id} deleted successfully from project {project_id}.")

--- a/uncertainty_engine/api_providers/resource_provider.py
+++ b/uncertainty_engine/api_providers/resource_provider.py
@@ -344,7 +344,9 @@ class ResourceProvider(ApiProviderBase):
             raise Exception(f"Error finalizing upload: {str(e)}")
 
     @ApiProviderBase.with_auth_refresh
-    def list_resources(self, project_id: str, resource_type: str) -> list[dict[str, Any]]:
+    def list_resources(
+        self, project_id: str, resource_type: str
+    ) -> list[dict[str, Any]]:
         """
         Get a list of all resources of a specific type in your project.
 


### PR DESCRIPTION
This PR adds a `delete_resource` method to the `ResourceProvider`. Follows a similar design to most of the other methods of the provider and can be used as follows:

```python
client.resources.delete_resource(
    project_id="your-project-123",
    resource_type="dataset",
    resource_id="resource-456",
)
```
```shell
"Resource resource-456 deleted successfully from project your-project-123."
```

This PR also makes some minor updates to the typing of the `list_resources` method of the `ResourceProvider` class. I did this because I was using this method during my testing and noticed a lack of typing for `project_id` and very generic response typing. Still room for improvement but better.