### PR TITLE
Update example notebooks with some help about project IDs

### DIFF
--- a/examples/demo_resource.ipynb
+++ b/examples/demo_resource.ipynb
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once authenticate you will have access to all of your available resources. In the Uncertainty Engine, resources always belong to a `project`, this helps keep your work organised and allows you to share resources with other users. You can think of a `project` as a folder that contains all of your resources. To make life easier we will define our project ID here.\n",
+    "Once authenticate you will have access to all of your available resources. In the Uncertainty Engine, resources always belong to a `project`, this helps keep your work organised and allows you to share resources with other users. You can think of a `project` as a folder that contains all of your resources. To make life easier we will define our project ID here. The IDs for your available projects can be accessed by executing the `client.projects.list_projects` method. This will return a list of your available projects. Each with an `\"id\"` field.\n",
     "\n",
     "Resources are split into different categories (e.g `dataset`, `document`, `model`, ...), listing resources is filtered by these categories. \n",
     "\n",

--- a/examples/demo_resource.ipynb
+++ b/examples/demo_resource.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.authenticate(\"YOUR-ACCCOUNT-ID\")"
+    "client.authenticate(\"YOUR-ACCOUNT-ID\")"
    ]
   },
   {
@@ -170,9 +170,8 @@
     "from io import BytesIO\n",
     "import pandas as pd\n",
     "\n",
-    "resource = client.resources.download(project_id=PROJECT_ID,\n",
-    "                          resource_type=\"dataset\",\n",
-    "                          resource_id=resource_id\n",
+    "resource = client.resources.download(\n",
+    "    project_id=PROJECT_ID, resource_type=\"dataset\", resource_id=resource_id\n",
     ")\n",
     "\n",
     "display(pd.read_csv(BytesIO(resource)))"

--- a/examples/demo_save_load_workflow.ipynb
+++ b/examples/demo_save_load_workflow.ipynb
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,11 +100,7 @@
     "\n",
     "graph = Graph()\n",
     "\n",
-    "add = Add(\n",
-    "  rhs=1,\n",
-    "  lhs=42,\n",
-    "  label=\"Add\"\n",
-    ")\n",
+    "add = Add(rhs=1, lhs=42, label=\"Add\")\n",
     "\n",
     "# Add the node to the graph\n",
     "graph.add_node(add)\n",
@@ -133,9 +129,7 @@
     "    graph=graph.nodes,\n",
     "    input=graph.external_input,\n",
     "    external_input_id=graph.external_input_id,\n",
-    "    requested_output={\n",
-    "      \"Add\": ans.model_dump()\n",
-    "    }\n",
+    "    requested_output={\"Add\": ans.model_dump()},\n",
     ")"
    ]
   },
@@ -230,13 +224,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "loaded_workflow = client.workflows.load(\n",
-    "    project_id=PROJECT_ID,\n",
-    "    workflow_id=basic_workflow_id\n",
+    "    project_id=PROJECT_ID, workflow_id=basic_workflow_id\n",
     ")"
    ]
   },
@@ -330,11 +323,6 @@
    "source": [
     "As you can see above `MyBasicAddWorkflow` now has another version in its list of versions."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/demo_save_load_workflow.ipynb
+++ b/examples/demo_save_load_workflow.ipynb
@@ -63,6 +63,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Authentication is carried out with the `client.authenticate` method. The IDs for your available projects can be accessed by executing the `client.projects.list_projects` method. This will return a list of your available projects. Each with an `\"id\"` field."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
This PR updates  the markdown in a couple of the example with some indication of how users can find their project IDs to ise when interacting with the resource service.

This PR also corrects some typos and runs black on the code cells in the updated example notebooks.