### PR TITLE
Pb 591 improve job status method typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ add = Add(lhs=1, rhs=2)
 response = client.run_node(add)
 
 # Get the result
-result = response["outputs"]
+result = response.outputs
 
 pprint(result)
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ client = Client(
 from pprint import pprint
 
 from uncertainty_engine import Client, Environment
-from uncertainty_engine.nodes.demo import Add
+from uncertainty_engine.nodes.basic import Add
 
 # Set up the client
 client = Client(
@@ -97,7 +97,7 @@ add = Add(lhs=1, rhs=2)
 response = client.run_node(add)
 
 # Get the result
-result = response["output"]
+result = response["outputs"]
 
 pprint(result)
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,7 +130,7 @@ You will need to make sure you have all the [prerequisites](#prerequisites) abov
 
    ```python
    response = client.run_node(add)
-   result = response["output"]
+   result = response.outputs
 
    pprint(result)
    ```

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -58,7 +58,7 @@ class TestClientMethods:
         status = ValidStatus.PENDING.value
         while status not in [ValidStatus.SUCCESS.value, ValidStatus.FAILURE.value]:
             response = e2e_client.job_status(job_id)
-            status = response["status"]
+            status = response.status.value
             time.sleep(5)
 
         assert status == ValidStatus.SUCCESS.value

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -141,10 +141,7 @@ class TestClientMethods:
             response = client.job_status(mock_job)
 
             assert isinstance(response, JobInfo)
-            assert response.status == JobStatus.RUNNING
-            assert response.message == "Job is running"
-            assert response.inputs == {"lhs": 1, "rhs": 2}
-            assert response.outputs is None
+            assert response == mock_job_info
 
     def test_queue_node_node_input(self, client: Client, mock_job: Job):
         """


### PR DESCRIPTION
- Changed the return type of job_status to a JobInfo object
- In order for the above to not break client.py, some adjustments were needed in run_node and _wait_for_job, which also now return a JobInfo object instead of a dict
- Made small changes to README.MD to follow the above changes (fixed an outdated import in the example and changed response["output"] to response.outputs)

NOTE: If there are any other places where client.run_node is called outside this repository, adjustments will need to be made there as well, in order to change the old accessing via dict to accessing via the object attributes. ⚠️