### PR TITLE
`PB-656:` Adding `prod` environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export UE_PASSWORD="your_password"
 
 ### Creating a client
 
-All interactions with the Uncertainty Engine API are performed via a `Client`. The client will use the production environment by default:
+All interactions with the Uncertainty Engine API are performed via a `Client`. The client can be defined as follows:
 
 ```python
 from uncertainty_engine import Client
@@ -42,7 +42,7 @@ from uncertainty_engine import Client
 client = Client()
 ```
 
-If you with to use a different environment you can create a `Client` for a named environment:
+To create a `Client` for a named environment:
 
 ```python
 from uncertainty_engine import Client

--- a/README.md
+++ b/README.md
@@ -34,9 +34,15 @@ export UE_PASSWORD="your_password"
 
 ### Creating a client
 
-All interactions with the Uncertainty Engine API are performed via a `Client`. The client will default to using the production environment. If you with to use a different environment you can do so by following the steps below.
+All interactions with the Uncertainty Engine API are performed via a `Client`. The client will use the production environment by default:
 
-To create a `Client` for a named environment:
+```python
+from uncertainty_engine import Client
+
+client = Client()
+```
+
+If you with to use a different environment you can create a `Client` for a named environment:
 
 ```python
 from uncertainty_engine import Client

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export UE_PASSWORD="your_password"
 
 ### Creating a client
 
-All interactions with the Uncertainty Engine API are performed via a `Client`.
+All interactions with the Uncertainty Engine API are performed via a `Client`. The client will default to using the production environment. If you with to use a different environment you can do so by following the steps below.
 
 To create a `Client` for a named environment:
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -16,7 +16,7 @@ def test_init_default() -> None:
     """
 
     client = Client()
-    assert client.env == Environment.get("local")
+    assert client.env == Environment.get("prod")
 
 
 def test_init_with_named_env() -> None:

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -58,7 +58,7 @@ class Client:
 
         Args:
             env: Environment configuration or name of a deployed environment.
-                Defaults to the production environment.
+                Defaults to the main Uncertainty Engine environment.
 
         Example:
             >>> client = Client(

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -51,14 +51,14 @@ class Job(BaseModel):
 class Client:
     def __init__(
         self,
-        env: Environment | str = "local",
+        env: Environment | str = "prod",
     ):
         """
         A client for interacting with the Uncertainty Engine.
 
         Args:
             env: Environment configuration or name of a deployed environment.
-                Defaults to a local development environment.
+                Defaults to the production environment.
 
         Example:
             >>> client = Client(

--- a/uncertainty_engine/environments/prod.json
+++ b/uncertainty_engine/environments/prod.json
@@ -1,0 +1,6 @@
+{
+    "cognito_user_pool_client_id": "3vj5pe253j4v070euqjdk38a24",
+    "core_api": "https://de1v75vvk6.execute-api.eu-west-2.amazonaws.com",
+    "region": "eu-west-2",
+    "resource_api": "https://m90q55iux6.execute-api.eu-west-2.amazonaws.com"
+}


### PR DESCRIPTION
This will allow connecting to the prod environment with:

```python
from uncertainty_engine import Client

client = Client()
```

- Added prod environment json
- Made `prod` the default environment for the client
- Updated the docs
- Updated the unit tests