### PR TITLE
PB-716: change input to inputs in client methods

### DIFF
--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -42,7 +42,7 @@ class TestClientMethods:
             "rhs": 2,
         }  # Inputs are left hand side and right hand side of equation
 
-        job_id = e2e_client.queue_node(node=node_name, input=inputs)
+        job_id = e2e_client.queue_node(node=node_name, inputs=inputs)
 
         # Add the job_id as an attribute of the test class so that it can be used in other tests
         TestClientMethods.job_id = job_id

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -111,7 +111,7 @@ class TestClientMethods:
 
             response = client.queue_node(
                 node=mock_job.node_id,
-                input={"key": "value"},
+                inputs={"key": "value"},
             )
 
         assert response == mock_job
@@ -270,7 +270,7 @@ class TestClientMethods:
                 outputs={"result": 42},
             )
 
-            client.run_node(node="node_a", input={"key": "value"})
+            client.run_node(node="node_a", inputs={"key": "value"})
 
             mock_queue_node.assert_called_once_with("node_a", {"key": "value"})
             mock_wait_for_job.assert_called_once_with(mock_job)

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -187,7 +187,9 @@ class Client:
         return Job(node_id=node, job_id=job_id)
 
     def run_node(
-        self, node: Union[str, Node], inputs: Optional[dict] = None
+        self,
+        node: Union[str, Node],
+        inputs: Optional[dict] = None,
     ) -> JobInfo:
         """
         Run a node synchronously.

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -156,21 +156,21 @@ class Client:
 
         return node_list
 
-    def queue_node(self, node: Union[str, Node], input: Optional[dict] = None) -> Job:
+    def queue_node(self, node: Union[str, Node], inputs: Optional[dict] = None) -> Job:
         """
         Queue a node for execution.
 
         Args:
             node: The name of the node to execute or the node object itself.
-            input: The input data for the node. If the node is defined by its name,
+            inputs: The input data for the node. If the node is defined by its name,
                 this is required. Defaults to ``None``.
 
         Returns:
             A Job object representing the queued job.
         """
         if isinstance(node, Node):
-            node, input = node()
-        elif isinstance(node, str) and input is None:
+            node, inputs = node()
+        elif isinstance(node, str) and inputs is None:
             raise ValueError(
                 "Input data/parameters are required when specifying a node by name."
             )
@@ -180,25 +180,27 @@ class Client:
             {
                 "email": self.email,
                 "node_id": node,
-                "inputs": input,
+                "inputs": inputs,
             },
         )
 
         return Job(node_id=node, job_id=job_id)
 
-    def run_node(self, node: Union[str, Node], input: Optional[dict] = None) -> JobInfo:
+    def run_node(
+        self, node: Union[str, Node], inputs: Optional[dict] = None
+    ) -> JobInfo:
         """
         Run a node synchronously.
 
         Args:
             node: The name of the node to execute or the node object itself.
-            input: The input data for the node. If the node is defined by its name,
+            inputs: The input data for the node. If the node is defined by its name,
                 this is required. Defaults to ``None``.
 
         Returns:
             A JobInfo object containing the response data of the job.
         """
-        job_id = self.queue_node(node, input)
+        job_id = self.queue_node(node, inputs)
         return self._wait_for_job(job_id)
 
     def job_status(self, job: Job) -> JobInfo:


### PR DESCRIPTION
- Changed input to inputs in relevant client methods and docstrings (where appropriate).
- Fixed failing tests (unit and e2e) that weren't passing due to expecting the replaced input parameter.