### PR TITLE
Remove unused "CognitoAuthenticator.get_access_token()" function

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -78,7 +78,7 @@ def mock_cognito_authenticator(
         "access_token": mock_access_token,
         "refresh_token": mock_refresh_token,
     }
-    mock_authenticator.get_access_token.return_value = mock_access_token
+
     mock_authenticator.refresh_tokens.return_value = {
         "access_token": mock_access_token,
         "id_token": mock_id_token,

--- a/tests/unit/test_cognito_authenticator.py
+++ b/tests/unit/test_cognito_authenticator.py
@@ -198,39 +198,6 @@ def test_authenticate_exception(
             "response": {
                 "AuthenticationResult": {
                     "AccessToken": "mock_access_token",
-                    "RefreshToken": "mock_refresh_token",
-                    "ExpiresIn": 3600,
-                    "TokenType": "Bearer",
-                }
-            },
-            "method_args": {
-                "AuthFlow": "USER_PASSWORD_AUTH",
-                "ClientId": "1234567890abcdef",
-                "AuthParameters": {"USERNAME": "testuser", "PASSWORD": "testpassword"},
-            },
-        }
-    ],
-    indirect=True,
-)
-def test_get_access_token(
-    cognito_client_stub, authenticator_args: dict[str, str], mock_access_token: str
-):
-    """Test the authenticate method of CognitoAuthenticator."""
-
-    authenticator = CognitoAuthenticator(**authenticator_args)
-    token = authenticator.get_access_token("testuser", "testpassword")
-
-    assert token == mock_access_token
-
-
-@pytest.mark.parametrize(
-    "cognito_client_stub",
-    [
-        {
-            "method": "initiate_auth",
-            "response": {
-                "AuthenticationResult": {
-                    "AccessToken": "mock_access_token",
                     "IdToken": "mock_id_token",
                     "ExpiresIn": 3600,
                     "TokenType": "Bearer",

--- a/uncertainty_engine/cognito_authenticator.py
+++ b/uncertainty_engine/cognito_authenticator.py
@@ -127,20 +127,6 @@ class CognitoAuthenticator:
         except Exception:
             raise
 
-    def get_access_token(self, username: str, password: str) -> str:
-        """Get only the access token from Cognito.
-
-        A convenience method to get just the access token.
-
-        Returns:
-            str: The access token
-
-        Raises:
-            Exception: If authentication fails
-        """
-        auth_result = self.authenticate(username, password)
-        return auth_result.get("access_token")
-
     def refresh_tokens(self, refresh_token: str) -> Dict:
         """Refresh tokens using a refresh token.
 


### PR DESCRIPTION
Remove the unused `CognitoAuthenticator.get_access_token()` function.

This will simplify my upcoming changes to the `CognitoAuthenticator.authenticate()` function.