### PR TITLE
Add "CognitoAuthenticator.get_cognito_response_value()" function

### DIFF
--- a/tests/unit/test_cognito_authenticator.py
+++ b/tests/unit/test_cognito_authenticator.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from botocore.stub import Stubber
 from mypy_boto3_cognito_idp.client import CognitoIdentityProviderClient
-from pytest import FixtureRequest
+from pytest import FixtureRequest, raises
 
 from uncertainty_engine.cognito_authenticator import CognitoAuthenticator
 
@@ -188,6 +188,19 @@ def test_authenticate_exception(
     with pytest.raises(KeyError):
         authenticator = CognitoAuthenticator(**authenticator_args)
         authenticator.authenticate("testuser", "testpassword")
+
+
+def test_get_cognito_response_value() -> None:
+    response = {"foo": "bar"}
+    value = CognitoAuthenticator.get_cognito_response_value(response, "foo")
+    assert value == "bar"
+
+
+def test_get_cognito_response_value_not_provided() -> None:
+    response = {"foo": "bar"}
+
+    with raises(KeyError, match="Cognito did not provide woo"):
+        CognitoAuthenticator.get_cognito_response_value(response, "woo")
 
 
 @pytest.mark.parametrize(

--- a/uncertainty_engine/cognito_authenticator.py
+++ b/uncertainty_engine/cognito_authenticator.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 import boto3
 import jwt
@@ -136,6 +136,27 @@ class CognitoAuthenticator:
             raise Exception(f"Authentication failed: {error_message}")
         except Exception:
             raise
+
+    @staticmethod
+    def get_cognito_response_value(response: Any, key: str) -> str:
+        """
+        Gets a specific value from a dictionary provided by Cognito.
+
+        Args:
+            response: Cognito response.
+            key: Value key.
+
+        Returns:
+            Response value.
+
+        Raises:
+            KeyError: Raised if the specified value is not present.
+        """
+
+        if value := response.get(key):
+            return str(value)
+
+        raise KeyError(f"Cognito did not provide {key}")
 
     def refresh_tokens(self, refresh_token: str) -> Dict:
         """Refresh tokens using a refresh token.


### PR DESCRIPTION
Add the new `CognitoAuthenticator.get_cognito_response_value()` function.

I'll this in upcoming work to avoid warnings about keys that Cognito might not provide and reduce code duplication.