### PR TITLE
Clean up Cognito Token tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -100,12 +100,16 @@ def mock_auth_service(mock_access_token: str, mock_account_id: str):
 
 @pytest.fixture
 def mock_auth_file_data(
-    mock_account_id: str, mock_access_token: str, mock_refresh_token: str
-):
+    mock_account_id: str,
+    mock_access_token: str,
+    mock_id_token: str,
+    mock_refresh_token: str,
+) -> dict[str, str]:
     """Default mock data for auth file"""
     return {
         "account_id": mock_account_id,
         "access_token": mock_access_token,
+        "id_token": mock_id_token,
         "refresh_token": mock_refresh_token,
     }
 

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 
@@ -159,9 +159,14 @@ def test_refresh_successful(
 
     # Setup new token values
     new_access_token = "new_access_token"
-    mock_cognito_authenticator.refresh_tokens.return_value = {
-        "access_token": new_access_token
-    }
+    new_id_token = "new_id_token"
+
+    mock_cognito_authenticator.refresh_tokens = Mock(
+        return_value={
+            "access_token": new_access_token,
+            "id_token": new_id_token,
+        },
+    )
 
     # Mock _save_to_file
     monkeypatch.setattr(auth_service, "_save_to_file", lambda: None)
@@ -170,6 +175,7 @@ def test_refresh_successful(
     result = auth_service.refresh()
 
     # Verify token was refreshed
+    assert auth_service.token
     assert result is auth_service.token
     assert auth_service.token.access_token == new_access_token
 

--- a/tests/unit/test_cognito_authenticator.py
+++ b/tests/unit/test_cognito_authenticator.py
@@ -92,6 +92,7 @@ def test_init(
             "response": {
                 "AuthenticationResult": {
                     "AccessToken": "mock_access_token",
+                    "IdToken": "mock_id_token",
                     "RefreshToken": "mock_refresh_token",
                     "ExpiresIn": 3600,
                     "TokenType": "Bearer",


### PR DESCRIPTION
- Add ID tokens to test cases in preparation for adding them to the `CognitoToken` class.
- Add a `CognitoToken` fixture and refactor existing tests to use it to reduce the code changes I'll need to make when I add ID tokens to the class.