### PR TITLE
Update "CognitoAuthenticator.refresh_tokens()" to return "CognitoToken"

### DIFF
--- a/tests/unit/test_cognito_authenticator.py
+++ b/tests/unit/test_cognito_authenticator.py
@@ -213,7 +213,7 @@ def test_get_cognito_response_value_not_provided() -> None:
             "method": "initiate_auth",
             "response": {
                 "AuthenticationResult": {
-                    "AccessToken": "mock_access_token",
+                    "AccessToken": "mock_refreshed_access_token",
                     "IdToken": "mock_id_token",
                     "ExpiresIn": 3600,
                     "TokenType": "Bearer",
@@ -230,21 +230,16 @@ def test_get_cognito_response_value_not_provided() -> None:
 )
 def test_refresh_tokens(
     cognito_client_stub,
-    mock_access_token: str,
     mock_refresh_token: str,
-    mock_id_token: str,
-):
+    mock_refreshed_cognito_tokens: CognitoToken,
+) -> None:
     region = "eu-west-1"
     client_id = "1234567890abcdef"
 
     authenticator = CognitoAuthenticator(region, client_id)
     tokens = authenticator.refresh_tokens(mock_refresh_token)
 
-    assert tokens == {
-        "access_token": mock_access_token,
-        "id_token": mock_id_token,
-        "expires_in": 3600,
-    }
+    assert tokens == mock_refreshed_cognito_tokens
 
 
 @pytest.mark.parametrize(

--- a/uncertainty_engine/auth_service.py
+++ b/uncertainty_engine/auth_service.py
@@ -109,10 +109,8 @@ class AuthService:
         if not self.token or not self.token.refresh_token:
             raise ValueError("No refresh token available. Please authenticate first.")
         try:
-            response = self.authenticator.refresh_tokens(self.token.refresh_token)
-            self.token = CognitoToken(
-                access_token=response["access_token"],
-                refresh_token=self.token.refresh_token,  # Keep existing refresh token
+            self.token = self.authenticator.refresh_tokens(
+                self.token.refresh_token,
             )
             self._save_to_file()
             return self.token

--- a/uncertainty_engine/cognito_authenticator.py
+++ b/uncertainty_engine/cognito_authenticator.py
@@ -160,14 +160,14 @@ class CognitoAuthenticator:
 
         raise KeyError(f"Cognito did not provide {key}")
 
-    def refresh_tokens(self, refresh_token: str) -> Dict:
+    def refresh_tokens(self, refresh_token: str) -> CognitoToken:
         """Refresh tokens using a refresh token.
 
         Args:
             refresh_token (str): The refresh token to use
 
         Returns:
-            Dict: A dictionary containing the new access token and ID token
+            Refreshed tokens.
 
         Raises:
             Exception: If token refresh fails
@@ -181,11 +181,12 @@ class CognitoAuthenticator:
 
             auth_result = response.get("AuthenticationResult", {})
 
-            return {
-                "access_token": auth_result.get("AccessToken"),
-                "id_token": auth_result.get("IdToken"),
-                "expires_in": auth_result.get("ExpiresIn", 3600),
-            }
+            return CognitoToken(
+                self.get_cognito_response_value(auth_result, "AccessToken"),
+                # The original code before I refactored this intentionally kept
+                # the same refresh token.
+                refresh_token,
+            )
 
         except ClientError as e:
             error_message = e.response.get("Error", {}).get("Message", "Unknown error")


### PR DESCRIPTION
- Update the `CognitoAuthenticator.refresh_tokens()` function to return a `CognitoToken` instance rather than an ad-hoc dictionary.
- Update the `mock_cognito_authenticator` test fixture to return a specific and strongly-typed `CognitoToken` with refreshed values.