### PR TITLE
Fix return type for "update_api_authentication()"

### DIFF
--- a/tests/unit/api_providers/test_api_provider.py
+++ b/tests/unit/api_providers/test_api_provider.py
@@ -25,7 +25,7 @@ class ApiProviderTestClass(ApiProviderBase):
         self.fail_count = count
         self.call_count = 0
 
-    def update_api_authentication(self):
+    def update_api_authentication(self) -> None:
         """Update auth header with token from auth_service"""
         self.auth_header = self.auth_service.get_auth_header()
 

--- a/uncertainty_engine/api_providers/api_provider.py
+++ b/uncertainty_engine/api_providers/api_provider.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, NoReturn, TypeVar
+from typing import Any, Callable, TypeVar
 
 from uncertainty_engine_resource_client.exceptions import UnauthorizedException
 
@@ -35,7 +35,7 @@ class ApiProviderBase:
 
         return wrapper
 
-    def update_api_authentication(self) -> NoReturn:
+    def update_api_authentication(self) -> None:
         """
         All API providers that wish to use token refreshing must implement this method.
         This method should update the authorization header in the api client.

--- a/uncertainty_engine/api_providers/projects_provider.py
+++ b/uncertainty_engine/api_providers/projects_provider.py
@@ -43,7 +43,7 @@ class ProjectsProvider(ApiProviderBase):
         # Update auth headers of the API client (only if authenticated)
         self.update_api_authentication()
 
-    def update_api_authentication(self) -> None:  # type: ignore
+    def update_api_authentication(self) -> None:
         """Update API client with current auth headers"""
         if self.auth_service.is_authenticated:
             auth_header = self.auth_service.get_auth_header()

--- a/uncertainty_engine/api_providers/resource_provider.py
+++ b/uncertainty_engine/api_providers/resource_provider.py
@@ -60,7 +60,7 @@ class ResourceProvider(ApiProviderBase):
         # Update auth headers of the API client (only if authenticated)
         self.update_api_authentication()
 
-    def update_api_authentication(self):
+    def update_api_authentication(self) -> None:
         """Update API client with current auth headers"""
         if self.auth_service.is_authenticated:
 

--- a/uncertainty_engine/api_providers/workflows_provider.py
+++ b/uncertainty_engine/api_providers/workflows_provider.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from pydantic import ValidationError
 from uncertainty_engine_resource_client.api import ProjectRecordsApi, WorkflowsApi
 from uncertainty_engine_resource_client.api_client import ApiClient
 from uncertainty_engine_resource_client.configuration import Configuration
@@ -26,7 +27,6 @@ from uncertainty_engine.api_providers.models import (
 from uncertainty_engine.auth_service import AuthService
 from uncertainty_engine.nodes.workflow import Workflow
 from uncertainty_engine.utils import format_api_error
-from pydantic import ValidationError
 
 
 class WorkflowsProvider(ApiProviderBase):
@@ -68,7 +68,7 @@ class WorkflowsProvider(ApiProviderBase):
         # Update auth headers of the API client (only if authenticated)
         self.update_api_authentication()
 
-    def update_api_authentication(self) -> None:  # type: ignore
+    def update_api_authentication(self) -> None:
         """Update API client with current auth headers"""
         if self.auth_service.is_authenticated:
 


### PR DESCRIPTION
The return type of `ApiProviderBase.update_api_authentication()` is currently `NoReturn`.

This is incorrect, since [it implies that the function never returns](https://docs.python.org/3/library/typing.html#typing.NoReturn). Implementations of the base function have been annotated with `# type: ignore` to satisfy linting.

This change corrects the base return type to `None` and removes the type ignoring that worked around it.