### PR TITLE
Remove `include_any_resource_token`

### DIFF
--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-from pytest import mark
 
 from uncertainty_engine.auth_service import AuthService
 from uncertainty_engine.cognito_authenticator import CognitoAuthenticator, CognitoToken

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -210,52 +210,21 @@ def test_refresh_exception(
         auth_service.clear.assert_called_once()
 
 
-def test_get_auth_header(auth_service_with_file: tuple[AuthService, MagicMock]):
+def test_get_auth_header(
+    auth_service_with_file: tuple[AuthService, MagicMock],
+    mock_access_token: str,
+    mock_resource_token: str,
+):
     """Test getting authorization header"""
     auth_service, _ = auth_service_with_file
 
     # Get auth header
-    header = auth_service.get_auth_header()
+    headers = auth_service.get_auth_header()
 
     # Verify header format
-    assert header == {"Authorization": f"Bearer {auth_service.token.access_token}"}
-
-
-@mark.parametrize(
-    "resource_token, expect_resource_header",
-    [
-        (None, "mock_access_token"),
-        ("this_resource_token", "this_resource_token"),
-    ],
-)
-def test_get_auth_header_with_any_resource_token(
-    auth_service_with_file: tuple[AuthService, MagicMock],
-    mock_access_token: str,
-    resource_token: str | None,
-    expect_resource_header: str,
-) -> None:
-    """
-    Asserts that `AuthService.get_auth_header()` returns the expected
-    "X-Resource-Service-Token" header when `include_any_resource_token` is
-    `True` and when a resource token is and isn't present.
-
-    Args:
-        auth_service_with_file: Tuple of an `AuthService` instance and IO for
-            a mock open of the authorisation cache file.
-        mock_access_token: Mock access token.
-        resource_token: Resource token to arrange for the test.
-        expect_resource_header: "X-Resource-Service-Token" header value to
-            expect.
-    """
-
-    auth_service, _ = auth_service_with_file
-    auth_service.resource_token = resource_token
-
-    headers = auth_service.get_auth_header(include_any_resource_token=True)
-
     assert headers == {
         "Authorization": f"Bearer {mock_access_token}",
-        "X-Resource-Service-Token": expect_resource_header,
+        "X-Resource-Service-Token": mock_resource_token,
     }
 
 
@@ -263,6 +232,7 @@ def test_get_auth_header_with_id(
     auth_service_with_file: tuple[AuthService, MagicMock],
     mock_access_token: str,
     mock_id_token: str,
+    mock_resource_token: str,
 ) -> None:
     auth_service, _ = auth_service_with_file
 
@@ -271,6 +241,7 @@ def test_get_auth_header_with_id(
     assert headers == {
         "Authorization": f"Bearer {mock_access_token}",
         "X-ID-Token": mock_id_token,
+        "X-Resource-Service-Token": mock_resource_token,
     }
 
 

--- a/uncertainty_engine/api_invoker.py
+++ b/uncertainty_engine/api_invoker.py
@@ -101,9 +101,7 @@ class HttpApiInvoker(ApiInvoker):
 
         kwargs = {
             "headers": {
-                **self._auth_service.get_auth_header(
-                    include_any_resource_token=True,
-                ),
+                **self._auth_service.get_auth_header(),
             },
         }
 
@@ -134,9 +132,7 @@ class HttpApiInvoker(ApiInvoker):
             # Update the authorisation header.
             kwargs["headers"] = {
                 **kwargs["headers"],
-                **self._auth_service.get_auth_header(
-                    include_any_resource_token=True,
-                ),
+                **self._auth_service.get_auth_header(),
             }
 
             # Remember that we've refreshed the token in case the next

--- a/uncertainty_engine/api_providers/auth_provider.py
+++ b/uncertainty_engine/api_providers/auth_provider.py
@@ -49,7 +49,6 @@ class AuthProvider(ApiProviderBase):
             # We expect to hit that endpoint only when we don't have a
             # resource token, so it's okay to populate the headers here
             # with the best token we have available at the time.
-            include_any_resource_token=True,
             include_id=True,
         )
 

--- a/uncertainty_engine/auth_service.py
+++ b/uncertainty_engine/auth_service.py
@@ -160,8 +160,10 @@ class AuthService:
         include_id: bool = False,
     ) -> dict[str, str]:
         """
-        Gets the authorisation and identity headers to include in an API
-        request.
+        Gets the authorisation and identity headers to include in an API request.
+
+        If the resource token is present it will be passed as the
+        "X-Resource-Service-Token", otherwise the access token will be passed instead.
 
         Args:
             include_id: Include an ID token as the "X-ID-Token" header.

--- a/uncertainty_engine/auth_service.py
+++ b/uncertainty_engine/auth_service.py
@@ -157,7 +157,6 @@ class AuthService:
 
     def get_auth_header(
         self,
-        include_any_resource_token: bool = False,
         include_id: bool = False,
     ) -> dict[str, str]:
         """
@@ -165,9 +164,6 @@ class AuthService:
         request.
 
         Args:
-            include_any_resource_token: Include the resource token as the
-                "X-Resource-Service-Token" header if that token is present,
-                otherwise pass the access token instead.
             include_id: Include an ID token as the "X-ID-Token" header.
 
         Returns:
@@ -178,12 +174,8 @@ class AuthService:
 
         headers = {
             "Authorization": f"Bearer {self.token.access_token}",
+            "X-Resource-Service-Token": self.resource_token or self.token.access_token,
         }
-
-        if include_any_resource_token:
-            headers["X-Resource-Service-Token"] = (
-                self.resource_token or self.token.access_token
-            )
 
         if include_id:
             headers["X-ID-Token"] = self.token.id_token


### PR DESCRIPTION
Remove the `include_any_resource_token` from the `get_auth_header` function as it is no longer required.