### PR TITLE
`PB-932`: Stop passing the username to "/nodes/queue"

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pytest
-
 from uncertainty_engine_types import JobInfo, JobStatus
 
 from tests.mock_api_invoker import mock_core_api
@@ -102,7 +101,6 @@ class TestClientMethods:
             api.expect_post(
                 "/nodes/queue",
                 expect_body={
-                    "email": client.email,
                     "node_id": mock_job.node_id,
                     "inputs": {"key": "value"},
                 },
@@ -157,7 +155,6 @@ class TestClientMethods:
             api.expect_post(
                 "/nodes/queue",
                 expect_body={
-                    "email": client.email,
                     "node_id": mock_job.node_id,
                     "inputs": {"key": "value"},
                 },

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -207,7 +207,6 @@ class Client:
         job_id = self.core_api.post(
             "/nodes/queue",
             {
-                "email": self.email,
                 "node_id": node,
                 "inputs": final_inputs,
             },


### PR DESCRIPTION
Stop passing the authenticated username to the `"/nodes/queue"` endpoint.