### PR TITLE
WIP: PB-882: add node info function in client

### DIFF
--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -64,3 +64,49 @@ class TestClientMethods:
             time.sleep(5)
 
         assert status == JobStatus.COMPLETED.value
+
+    def test_node_info(self, e2e_client: Client):
+        """
+        Verify that the node_info method returns correct information
+        for the Add node.
+
+        Args:
+            e2e_client: A Client instance.
+        """
+        node_id = "Add"
+        node_info = e2e_client.node_info(node_id)
+
+        assert node_info.id == "Add"
+        assert node_info.label == "Add"
+        assert node_info.category == "Basic"
+        assert node_info.description == "Add two numbers"
+        assert node_info.long_description == "Add two numbers"
+        assert node_info.image_name == "uncertainty-engine-add-node"
+        assert node_info.cost == 1
+
+        # Check inputs
+        assert "lhs" in node_info.inputs
+        assert node_info.inputs["lhs"].type == "float"
+        assert node_info.inputs["lhs"].label == "LHS"
+        assert node_info.inputs["lhs"].description == "Left-hand side of the addition"
+
+        assert "rhs" in node_info.inputs
+        assert node_info.inputs["rhs"].type == "float"
+        assert node_info.inputs["rhs"].label == "RHS"
+        assert node_info.inputs["rhs"].description == "Right-hand side of the addition"
+
+        # Check outputs
+        assert "ans" in node_info.outputs
+        assert node_info.outputs["ans"].type == "float"
+        assert node_info.outputs["ans"].label == "Answer"
+        assert node_info.outputs["ans"].description == "Result of the addition"
+
+        # Check requirements
+        assert node_info.requirements.cpu == 256
+        assert node_info.requirements.gpu is False
+        assert node_info.requirements.memory == 512
+        assert node_info.requirements.timeout == 15
+
+        # Check URLs
+        assert node_info.load_balancer_url.startswith("http://dev-un-uncer")
+        assert node_info.queue_url.startswith("https://sqs.eu-west-2.amazonaws.com/")

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -120,5 +120,7 @@ class TestClientMethods:
         assert node_info.requirements.timeout == 15
 
         # Check URLs
-        assert node_info.load_balancer_url.startswith("http://dev-un-uncer")
+        assert node_info.load_balancer_url.startswith(
+            ("http://dev-un-uncer", "http://prod-un-uncer")
+        )
         assert node_info.queue_url.startswith("https://sqs.eu-west-2.amazonaws.com/")

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -77,50 +77,16 @@ class TestClientMethods:
         assert isinstance(tokens, int)
         assert tokens >= 0
 
-    def test_get_node_info(self, e2e_client: Client):
+    def test_get_node_info(self, e2e_client: Client) -> None:
         """
-        Verify that the `get_node_info` method returns correct
-        information for the `Add` node.
+        Test that the `Add` node info returns the correct id, and that
+        all inputs and outputs exist and are not empty.
 
         Args:
-            e2e_client: A `Client` instance.
+            e2e_client: A Client instance.
         """
-        node_id = "Add"
-        node_info = e2e_client.get_node_info(node_id)
 
+        node_info = e2e_client.get_node_info("Add")
         assert node_info.id == "Add"
-        assert node_info.label == "Add"
-        assert node_info.category == "Basic"
-        assert node_info.description == "Add two numbers"
-        assert node_info.long_description == "Add two numbers"
-        assert node_info.image_name == "uncertainty-engine-add-node"
-        assert node_info.cost == 1
-
-        # Check inputs
-        assert "lhs" in node_info.inputs
-        assert node_info.inputs["lhs"].type == "float"
-        assert node_info.inputs["lhs"].label == "LHS"
-        assert node_info.inputs["lhs"].description == "Left-hand side of the addition"
-
-        assert "rhs" in node_info.inputs
-        assert node_info.inputs["rhs"].type == "float"
-        assert node_info.inputs["rhs"].label == "RHS"
-        assert node_info.inputs["rhs"].description == "Right-hand side of the addition"
-
-        # Check outputs
-        assert "ans" in node_info.outputs
-        assert node_info.outputs["ans"].type == "float"
-        assert node_info.outputs["ans"].label == "Answer"
-        assert node_info.outputs["ans"].description == "Result of the addition"
-
-        # Check requirements
-        assert node_info.requirements.cpu == 256
-        assert node_info.requirements.gpu is False
-        assert node_info.requirements.memory == 512
-        assert node_info.requirements.timeout == 15
-
-        # Check URLs
-        assert node_info.load_balancer_url.startswith(
-            ("http://dev-un-uncer", "http://prod-un-uncer")
-        )
-        assert node_info.queue_url.startswith("https://sqs.eu-west-2.amazonaws.com/")
+        assert node_info.inputs
+        assert node_info.outputs

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -71,7 +71,7 @@ class TestClientMethods:
         representing the number of available tokens.
 
         Args:
-            e2e_client: A `Client` instance.
+            e2e_client: A Client instance.
         """
         tokens = e2e_client.view_tokens()
         assert isinstance(tokens, int)

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -69,8 +69,9 @@ class TestClientMethods:
         """
         Verify that the `view_tokens` method returns an integer
         representing the number of available tokens.
+
         Args:
-            e2e_client: A Client instance.
+            e2e_client: A `Client` instance.
         """
         tokens = e2e_client.view_tokens()
         assert isinstance(tokens, int)
@@ -78,10 +79,11 @@ class TestClientMethods:
 
     def test_node_info(self, e2e_client: Client):
         """
-        Verify that the node_info method returns correct information
-        for the Add node.
+        Verify that the `node_info` method returns correct information
+        for the `Add` node.
+
         Args:
-            e2e_client: A Client instance.
+            e2e_client: A `Client` instance.
         """
         node_id = "Add"
         node_info = e2e_client.node_info(node_id)

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -77,16 +77,16 @@ class TestClientMethods:
         assert isinstance(tokens, int)
         assert tokens >= 0
 
-    def test_node_info(self, e2e_client: Client):
+    def test_get_node_info(self, e2e_client: Client):
         """
-        Verify that the `node_info` method returns correct information
-        for the `Add` node.
+        Verify that the `get_node_info` method returns correct
+        information for the `Add` node.
 
         Args:
             e2e_client: A `Client` instance.
         """
         node_id = "Add"
-        node_info = e2e_client.node_info(node_id)
+        node_info = e2e_client.get_node_info(node_id)
 
         assert node_info.id == "Add"
         assert node_info.label == "Add"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -271,3 +271,35 @@ class TestClientMethods:
 
             mock_queue_node.assert_called_once_with("node_a", {"key": "value"})
             mock_wait_for_job.assert_called_once_with(mock_job)
+
+    def test_node_info(self, client: Client):
+        """
+        Verify that the node_info method pokes the correct endpoint and
+        returns a NodeInfo object.
+
+        Args:
+            client: A Client instance.
+        """
+        with mock_core_api(client) as api:
+            node_id = "node_a"
+            node_info_dict = {
+                "id": node_id,
+                "label": node_id,
+                "category": "test_category",
+                "description": "A test node",
+                "long_description": "A long description for the test node.",
+                "image_name": "test_image.png",
+                "cost": 10,
+                "inputs": {},
+                "outputs": {},
+                "version_types_lib": "1.0.0",
+                "version_base_image": 1,
+                "version_node": 1,
+            }
+            api.expect_get(f"/nodes/{node_id}", node_info_dict)
+
+            response = client.node_info(node_id)
+
+            assert response.id == node_id
+            assert response.label == node_id
+            assert response.description == "A test node"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -277,7 +277,7 @@ class TestClientMethods:
         Verify that the `view_tokens` method pokes the correct endpoint.
 
         Args:
-            client: A `Client` instance.
+            client: A Client instance.
         """
         with mock_core_api(client) as api:
             api.expect_get(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -287,10 +287,10 @@ class TestClientMethods:
 
             client.view_tokens()
 
-    def test_node_info(self, client: Client):
+    def test_get_node_info(self, client: Client):
         """
-        Verify that the `node_info` method pokes the correct endpoint
-        and returns a `NodeInfo` object.
+        Verify that the `get_node_info` method pokes the correct
+        endpoint and returns a `NodeInfo` object.
 
         Args:
             client: A `Client` instance.
@@ -313,4 +313,4 @@ class TestClientMethods:
             }
             api.expect_get(f"/nodes/{node_id}", node_info_dict)
 
-            client.node_info(node_id)
+            client.get_node_info(node_id)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -313,8 +313,4 @@ class TestClientMethods:
             }
             api.expect_get(f"/nodes/{node_id}", node_info_dict)
 
-            response = client.node_info(node_id)
-
-            assert response.id == node_id
-            assert response.label == node_id
-            assert response.description == "A test node"
+            client.node_info(node_id)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -275,8 +275,9 @@ class TestClientMethods:
     def test_view_tokens(self, client: Client) -> None:
         """
         Verify that the `view_tokens` method pokes the correct endpoint.
+
         Args:
-            client: A Client instance.
+            client: A `Client` instance.
         """
         with mock_core_api(client) as api:
             api.expect_get(
@@ -288,10 +289,11 @@ class TestClientMethods:
 
     def test_node_info(self, client: Client):
         """
-        Verify that the node_info method pokes the correct endpoint and
-        returns a NodeInfo object.
+        Verify that the `node_info` method pokes the correct endpoint
+        and returns a `NodeInfo` object.
+
         Args:
-            client: A Client instance.
+            client: A `Client` instance.
         """
         with mock_core_api(client) as api:
             node_id = "node_a"

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -178,7 +178,7 @@ class Client:
 
         return node_list
 
-    def node_info(self, node: str) -> NodeInfo:
+    def get_node_info(self, node: str) -> NodeInfo:
         """
         Get information about a specific node.
 

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Union
 
 from pydantic import BaseModel
 from typeguard import typechecked
-from uncertainty_engine_types import JobInfo, JobStatus
+from uncertainty_engine_types import JobInfo, JobStatus, NodeInfo
 
 from uncertainty_engine.api_invoker import ApiInvoker, HttpApiInvoker
 from uncertainty_engine.api_providers import (
@@ -174,6 +174,20 @@ class Client:
             node_list = [node for node in node_list if node["category"] == category]
 
         return node_list
+
+    def node_info(self, node: str) -> NodeInfo:
+        """
+        Get information about a specific node.
+
+        Args:
+            node: The ID of the node to get information about.
+
+        Returns:
+            Information about the node as a NodeInfo object.
+        """
+
+        node_info = self.core_api.get(f"/nodes/{node}")
+        return NodeInfo(**node_info)
 
     def queue_node(
         self,


### PR DESCRIPTION
This PR adds a new method in the `Client` object, called `node_info`, which calls the relevant core API endpoint and returns the information of a node, given its id. It also adds a relevant unit and e2e test.