### PR TITLE
PB-1010: update view_tokens to return available tokens

### DIFF
--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -64,3 +64,15 @@ class TestClientMethods:
             time.sleep(5)
 
         assert status == JobStatus.COMPLETED.value
+
+    def test_view_tokens(self, e2e_client: Client) -> None:
+        """
+        Verify that the `view_tokens` method returns an integer
+        representing the number of available tokens.
+
+        Args:
+            e2e_client: A Client instance.
+        """
+        tokens = e2e_client.view_tokens()
+        assert isinstance(tokens, int)
+        assert tokens >= 0

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -271,3 +271,22 @@ class TestClientMethods:
 
             mock_queue_node.assert_called_once_with("node_a", {"key": "value"})
             mock_wait_for_job.assert_called_once_with(mock_job)
+
+    def test_view_tokens(self, client: Client) -> None:
+        """
+        Verify that the `view_tokens` method pokes the correct endpoint
+        and returns an integer.
+
+        Args:
+            client: A Client instance.
+        """
+        with mock_core_api(client) as api:
+            api.expect_get(
+                "/organizations/tokens/available",
+                123,
+            )
+
+            tokens = client.view_tokens()
+
+            assert isinstance(tokens, int)
+            assert tokens == 123

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -274,8 +274,7 @@ class TestClientMethods:
 
     def test_view_tokens(self, client: Client) -> None:
         """
-        Verify that the `view_tokens` method pokes the correct endpoint
-        and returns an integer.
+        Verify that the `view_tokens` method pokes the correct endpoint.
 
         Args:
             client: A Client instance.
@@ -286,7 +285,4 @@ class TestClientMethods:
                 123,
             )
 
-            tokens = client.view_tokens()
-
-            assert isinstance(tokens, int)
-            assert tokens == 123
+            client.view_tokens()

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -265,7 +265,7 @@ class Client:
     def view_tokens(self) -> int:
         """
         View the number of tokens currently available to the user's
-        organisation by calling the relevant core API endpoint.
+        organisation.
 
         Returns:
             The number of tokens currently available to the user's

--- a/uncertainty_engine/client.py
+++ b/uncertainty_engine/client.py
@@ -262,19 +262,17 @@ class Client:
         response_data = self.core_api.get(f"/nodes/status/{job.node_id}/{job.job_id}")
         return JobInfo(**response_data)
 
-    def view_tokens(self) -> Optional[int]:
+    def view_tokens(self) -> int:
         """
-        View how many tokens the user currently has available.
+        View the number of tokens currently available to the user's
+        organisation by calling the relevant core API endpoint.
 
         Returns:
-            Number of tokens the user currently has available.
+            The number of tokens currently available to the user's
+            organisation.
         """
 
-        # The token service for the new backend is not yet implemented.
-        # This is a placeholder for when the service is implemented.
-        # TODO: Make a request to the token service to get the user's token balance once it is implemented.
-        # response = requests.get(f"{self.deployment}/tokens/user/{self.email}")
-        tokens = 100
+        tokens = self.core_api.get("/organizations/tokens/available")
 
         return tokens
 


### PR DESCRIPTION
This PR updates the `client.view_tokens()` method to return the integer representing the available tokens by making a GET request to the the core API's `GET /tokens/available`.

It also adds two relevant tests.