### PR TITLE
PB-1108: add class for LoadDataset

### DIFF
--- a/tests/unit/nodes/test_resource_management.py
+++ b/tests/unit/nodes/test_resource_management.py
@@ -1,0 +1,23 @@
+from uncertainty_engine_types import ResourceID
+
+from uncertainty_engine.nodes.resource_management import LoadDataset
+
+
+def test_loaddataset_initialization() -> None:
+    """Test the initialization of the LoadDataset node."""
+
+    # Example values
+    project_id = "projectid-123"
+    file_id = ResourceID(id="fileid-456")
+    label = "Test Load Dataset"
+
+    node = LoadDataset(
+        project_id=project_id,
+        file_id=file_id,
+        label=label,
+    )
+
+    assert node.node_name == "LoadDataset"
+    assert node.project_id == project_id
+    assert node.file_id == file_id
+    assert node.label == label

--- a/uncertainty_engine/nodes/resource_management.py
+++ b/uncertainty_engine/nodes/resource_management.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from typeguard import typechecked
+from uncertainty_engine_types import ResourceID
+
+from uncertainty_engine.nodes.base import Node
+
+
+@typechecked
+class LoadDataset(Node):
+    """
+    Load a dataset from the Uncertainty Engine resource management
+    system.
+
+    Args:
+       project_id: The ID of the project containing the dataset.
+       file_id: The ID of the dataset file to load.
+       label: A human-readable label for the node. Defaults to None.
+    """
+
+    node_name: str = "LoadDataset"
+
+    def __init__(
+        self,
+        project_id: str,
+        file_id: ResourceID,
+        label: Optional[str] = None,
+    ):
+        super().__init__(
+            node_name=self.node_name,
+            label=label,
+            project_id=project_id,
+            file_id=file_id,
+        )
+        self.project_id = project_id
+        self.file_id = file_id
+        self.label = label


### PR DESCRIPTION
This PR creates a new class for the LoadDataset node and adds a very simple unit test for it. There will be a second PR that will update any notebooks currently using this node, but with the base Node class.