### PR TITLE
`PB-1750`: Add instructions for using custom environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ client = Client(
 
 ### Troubleshooting
 
-Authorisation tokens are cached under `.ue_auth` in your home directory. If the SDK fails to authenticate you (for example, after switching from one environment to another), delete `.ue_auth` to generate and cache new tokens.
+Authorisation tokens are cached in `.ue_auth` in your home directory. If the SDK fails to authenticate you (for example, after switching from one environment to another), delete `.ue_auth` to generate and cache new tokens.
 
 To delete the cache in macOS or Linux:
 
 ```bash
-rm -rf ~/.ue_auth
+rm ~/.ue_auth
 ```
 
 To delete the cache in Windows:
 
 ```bat
-rmdir /s %USERPROFILE%\.ue_auth
+del %USERPROFILE%\.ue_auth
 ```
 
 ### Running a node

--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ client = Client(
 
 **Note:** Every password is tied to a specific environment. A password for the production environment, for example, won't grant access to the development environment. Ensure you set the correct `UE_PASSWORD` value for the environment you configure.
 
+### Troubleshooting
+
+Authorisation tokens are cached under `.ue_auth` in your home directory. If the SDK fails to authenticate you (for example, after switching from one environment to another), delete `.ue_auth` to generate and cache new tokens.
+
+To delete the cache in macOS or Linux:
+
+```bash
+rm -rf ~/.ue_auth
+```
+
+To delete the cache in Windows:
+
+```bat
+rmdir /s %USERPROFILE%\.ue_auth
+```
+
 ### Running a node
 
 ```python

--- a/README.md
+++ b/README.md
@@ -50,6 +50,38 @@ With an instantiated `Client` object, and username and password set as environme
 client.authenticate()
 ```
 
+### Using different environments
+
+The `Client` defaults to using the Uncertainty Engine production environment. To use a different named environment, pass it as the `env` argument:
+
+```python
+client = Client(env="dev")
+```
+
+If a custom environment has been provided for you, pass an `Environment` that describes the details:
+
+```python
+from uncertainty_engine import Client, Environment
+
+client = Client(
+   env=Environment(
+        cognito_user_pool_client_id="…",
+        core_api="…",
+        region="…",
+        resource_api="…",
+   ),
+)
+```
+
+| Argument                      | Format                                        | Example                                                  |
+| ----------------------------- | --------------------------------------------- | -------------------------------------------------------- |
+| `cognito_user_pool_client_id` | Alphanumeric string                           | `3vj5pe253j4v070euqjdk38a24`                             |
+| `core_api`                    | Starts with `https://`, does not end with `/` | `https://de1v75vvk6.execute-api.eu-west-2.amazonaws.com` |
+| `region`                      | Geographic region code                        | `eu-west-2`                                              |
+| `resource_api`                | Starts with `https://`, does not end with `/` | `https://m90q55iux6.execute-api.eu-west-2.amazonaws.com` |
+
+**Note:** Every password is tied to a specific environment. A password for the production environment, for example, won't grant access to the development environment. Ensure you set the correct `UE_PASSWORD` value for the environment you configure.
+
 ### Running a node
 
 ```python

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ rm ~/.ue_auth
 To delete the cache in Windows:
 
 ```bat
-del %USERPROFILE%\.ue_auth
+del "%USERPROFILE%\.ue_auth"
 ```
 
 ### Running a node

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ If a custom environment has been provided for you, pass an `Environment` that de
 from uncertainty_engine import Client, Environment
 
 client = Client(
-   env=Environment(
+    env=Environment(
         cognito_user_pool_client_id="…",
         core_api="…",
         region="…",
         resource_api="…",
-   ),
+    ),
 )
 ```
 


### PR DESCRIPTION
# Add instructions for using custom environments

## Description

The `Client` class defaults to using the production environment, but also supports a range of named environments and entirely custom configurations for ad-hoc environments. However, the documentation doesn't reveal how to take advantage of those.

This change updates `README.md` to include instructions on using custom environments.

Resolves [PB-1750](https://digilab-ai.atlassian.net/browse/PB-1750).

## Docstring & Example Checklist

- [x] I have added or updated docstrings for all public classes, methods, and functions
- [x] I have included doctest-style examples in docstrings where appropriate
- [x] All examples use correct Python prompt formatting (``>>>``, ``...`` for continuation lines)
- [x] All code, class, and method names in docstrings are wrapped in backticks (e.g. `` `Add` ``)
