### PR TITLE
Release/0.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uncertainty-engine"
-version = "0.13.0"
+version = "0.14.0"
 description = "SDK for the Uncertainty Engine"
 authors = [
     { name = "digiLab Solutions Ltd.", email = "info@digilab.ai" },

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -1,4 +1,3 @@
-import os
 import time
 from unittest.mock import Mock, patch
 

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -87,10 +87,6 @@ class TestClientMethods:
         assert isinstance(tokens, int)
         assert tokens >= 0
 
-    @pytest.mark.skipif(
-        os.getenv("UE_ENVIRONMENT") == "prod",
-        reason="Get node info feature is not available in prod environment",
-    )
     def test_get_node_info(self, e2e_client: Client) -> None:
         """
         Test that the `Add` node info returns the correct id, and that
@@ -288,10 +284,6 @@ class TestClientMethods:
         assert all(isinstance(v, (str, int)) for v in versions)
         assert len(versions) > 0
 
-    @pytest.mark.skipif(
-        os.getenv("UE_ENVIRONMENT") == "prod",
-        reason="Query nodes feature is not available in prod environment",
-    )
     def test_query_nodes(self, e2e_client: Client):
         """
         Verify that query_nodes returns expected node info dict on success.
@@ -306,10 +298,6 @@ class TestClientMethods:
         assert node_info.id == "Add"
         assert node_info.label == "Add"
 
-    @pytest.mark.skipif(
-        os.getenv("UE_ENVIRONMENT") == "prod",
-        reason="Query nodes feature is not available in prod environment",
-    )
     def test_query_nodes_http_error(self, e2e_client: Client):
         """
         Verify that query_nodes re-raises HTTPError when detail is not a dict.

--- a/tests/e2e/test_client_e2e.py
+++ b/tests/e2e/test_client_e2e.py
@@ -290,10 +290,10 @@ class TestClientMethods:
         Args:
             e2e_client: A Client instance.
         """
-        queries = [NodeQuery(node_id="Add", version="latest")]
+        queries = [NodeQuery(node_id="Add", version="0.2.0")]
         result = e2e_client.query_nodes(queries)
-        assert "Add@latest" in result
-        node_info = result["Add@latest"]
+        assert "Add@0.2.0" in result
+        node_info = result["Add@0.2.0"]
         assert node_info.id == "Add"
         assert node_info.label == "Add"
 


### PR DESCRIPTION
This PR makes the preparation changes for the 0.14.0 release:

- Version bumped to `0.14.0`.
- Remove the test skips related to version querying.
