### PR TITLE
PB-1420: Add Windows to CI testing matrix

### DIFF
--- a/.github/workflows/unit_functional_tests.yaml
+++ b/.github/workflows/unit_functional_tests.yaml
@@ -11,10 +11,6 @@ on:
 env:
   UE_USERNAME: ${{ secrets.UE_USER_EMAIL }}
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   unit_tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit_functional_tests.yaml
+++ b/.github/workflows/unit_functional_tests.yaml
@@ -11,13 +11,18 @@ on:
 env:
   UE_USERNAME: ${{ secrets.UE_USER_EMAIL }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   unit_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +40,7 @@ jobs:
         run: poetry install --all-extras
 
       - name: Run unit tests
-        run: sh CI/run_tests_unit.sh
+        run: poetry run pytest tests/unit
 
       - name: Run functional tests
-        run: sh CI/run_tests_functional.sh
+        run: poetry run pytest tests/functional

--- a/CI/run_tests_functional.sh
+++ b/CI/run_tests_functional.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-poetry run pytest tests/functional

--- a/CI/run_tests_unit.sh
+++ b/CI/run_tests_unit.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-poetry run pytest tests/unit

--- a/git_hooks/pre-push
+++ b/git_hooks/pre-push
@@ -10,4 +10,4 @@ echo "[2/3] Running linter..."
 sh ./CI/run_linter.sh
 
 echo "[3/3] Running unit tests..."
-sh ./CI/run_tests_unit.sh
+poetry run pytest tests/unit


### PR DESCRIPTION
## Summary

Adds `windows-latest` to the CI testing matrix for unit and functional tests, ensuring the SDK is validated on Windows.

## Changes

- Added `os: [ubuntu-latest, windows-latest]` to the strategy matrix
- Set `defaults: run: shell: bash` at the workflow level (Git Bash is available on Windows runners)
- Replaced `sh CI/run_tests_unit.sh` and `sh CI/run_tests_functional.sh` with direct `poetry run pytest` commands for cross-platform compatibility

## What was tested

- CI will run on this PR to validate the Windows matrix works end-to-end