### PR TITLE
Bump pyjwt from 2.12.1 to 2.13.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2772,14 +2772,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
-    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
+    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
+    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
 ]
 
 [package.dependencies]
@@ -2787,9 +2787,6 @@ typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pyparsing"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -207,7 +207,7 @@ def mock_resource_token() -> str:
         {
             "account_id": "test_account",
         },
-        "",
+        "mock_signing_key",
     )
 
 


### PR DESCRIPTION
## Description

Routine dependency update: bumps pyjwt from 2.12.1 to 2.13.0 in the lock file.

How pyjwt is pulled in:

- It is a direct runtime dependency (`pyjwt = "^2.10.1"` in `pyproject.toml`) and nothing else in the dependency graph requires it (`poetry show --tree` lists it only as a top-level entry), so the SDK's own code is the only consumer.
- The `^2.10.1` constraint already admits 2.13.0, so only `poetry.lock` changes. Published package metadata is untouched: downstream installs resolve their own pyjwt within `>=2.10.1,<3` and are unaffected by this PR, which only moves the version the SDK itself is developed and tested against.
- pyjwt's only dependency is `typing_extensions >=4.0`, already present in the lock, so there are no transitive changes.

Compatibility notes:

- The SDK's runtime pyjwt usage is two `jwt.decode(..., options={"verify_signature": False})` call sites (`auth_service.py`, `cognito_authenticator.py`). No signing key is processed on that path, and neither call site uses the APIs whose behaviour changed in 2.13.0 (`PyJWK`/`PyJWKClient`, detached payloads, key-length enforcement), so no SDK code changes are needed.
- pyjwt 2.13.0 raises `InvalidKeyError` for empty HMAC signing keys, which the `mock_resource_token` test fixture relied on. The fixture now signs with a non-empty dummy key; nothing verifies that token's signature, so the value is arbitrary.
- The full unit suite passes (332 passed, 1 skipped). Before the fixture fix it failed with 19 errors under 2.13.0, so the suite demonstrably exercises the changed behaviour.


