### PR TITLE
SDK-180: Update Pygments to 2.20.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2756,14 +2756,14 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
-    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 markers = {main = "extra == \"notebook\""}
 


### PR DESCRIPTION
Bumps Pygments from 2.19.1 to 2.20.0 via `poetry update pygments`. Only `poetry.lock` is changed; the `pyproject.toml` constraint is untouched.

[Pygments](https://pygments.org/) is a transitive, notebook-extra/dev-only dependency (via ipython and pytest - `poetry show pygments`) used for syntax highlighting. 